### PR TITLE
overhaul to support hapi v8

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,23 @@
+{
+  "env": {
+    "node": true
+  },
+
+  "ecmaFeatures": {
+    "arrowFunctions": true,
+    "templateStrings": true,
+    "blockBindings": true
+  },
+
+  "globals": {
+
+  },
+
+  "rules": {
+    "quotes": [2, "single", "avoid-escape"],
+    "strict": 0,
+    "no-comma-dangle": 0,
+    "no-underscore-dangle": 0,
+    "no-use-before-define" : 0
+  }
+}

--- a/lib/rollbar.js
+++ b/lib/rollbar.js
@@ -2,5 +2,5 @@ var rollbar = require('rollbar');
 
 module.exports = function(accessToken) {
   rollbar.init(accessToken);
-  return rollbar.handleError;
-}
+  return rollbar;
+};

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "icecreambar",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "hapi plugin for rollbar error logging",
   "main": "index.js",
   "scripts": {
-    "test": "node test/index"
+    "test": "node --use_strict --harmony_arrow_functions ./node_modules/.bin/lab --lint -c"
   },
   "repository": {
     "type": "git",
@@ -19,11 +19,7 @@
     "log",
     "logging"
   ],
-  "author": "johnny domino <johnny@yayuhh.com>",
-  "contributors": [
-    "johnny domino <johnny@yayuhh.com>",
-    "john bauer <notjrbauer@gmail.com>"
-  ],
+  "author": "johnny domino <jvdomino@gmail.com>",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/yayuhh/icecreambar/issues"
@@ -32,8 +28,11 @@
     "rollbar": "0.x.x"
   },
   "devDependencies": {
-    "hapi": "6.x.x",
+    "boom": "^2.8.0",
+    "code": "^1.4.1",
+    "hapi": "8.x.x",
+    "lab": "jmonster/lab#86cea3afa6ee4ca328715529b13e2772234bf09e",
     "rollbar": "0.x.x",
-    "tape": "2.x.x"
+    "sinon": "^1.15.3"
   }
 }

--- a/test/log.js
+++ b/test/log.js
@@ -1,0 +1,37 @@
+const Hapi = require('hapi');
+const Code = require('code');
+const Lab = require('lab');
+const Plugin = {
+  register: require('../index.js'),
+  options: {
+    'accessToken': '58b67946b9af48e8ad07595afe9d63b2'
+  }
+};
+
+const expect = Code.expect;
+const lab = exports.lab = Lab.script();
+
+let server;
+
+lab.experiment('log', function () {
+
+  lab.beforeEach(function(done) {
+
+    server = new Hapi.Server();
+    server.connection({});
+    done();
+  });
+
+
+  lab.test('handleError is called when server.log("rollbarError")', function (done) {
+
+    server.register(Plugin, function (/*err*/) {
+
+      server.plugins.icecreambar.rollbar.handleError = require('sinon').spy();
+      server.log('rollbarError');
+
+      expect(server.plugins.icecreambar.rollbar.handleError.called).to.equal(true);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
# icecreambar v2
## Checklist
- [x] compatibility with hapi ^8.6.1
- [x] support `multiple` registrations of this plugin
- [x] provide a `scope` parameter to distinguish between multiple registrations
- [x] capture `request-error`'s
- [x] capture `server.log`'s when tags match `rollbarError` or `rollbarMessage`
  - filter on `scope` when provided
- [x] capture non-5xx errors observed in `onPreResponse`, filtered by `options.relevantPaths` [to avoid reporting the same error for every registration of this plugin]
- [ ] provide 100% code coverage
