### PR TITLE
omit specified response codes from being reported to rollbar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.12"
-  - "iojs"
+  - "4.2.2"
 notifications:
   email: false
 cache:

--- a/README.markdown
+++ b/README.markdown
@@ -79,7 +79,8 @@ server.register({
   options: {
     'accessToken': '58b67946b9af48e8ad07595afe9d63b2',
     'scope': 'sre',                                    // namespace for this instance of rollbar
-    'relevantPaths': ['/uptime', '/auth']              // http path(s) that this instance shall report on
+    'relevantPaths': ['/uptime', '/auth'],             // http path(s) that this instance shall report on
+    'omittedResponseCodes': [401]                      // do not log 401 responses
   }
 }, function (err) {
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  node:
+    version: v4.2.2

--- a/index.js
+++ b/index.js
@@ -75,8 +75,11 @@ exports.register = function (server, options, next) {
 
       // don't duplicate server.on('request-error', ...)
       const responseIsNot5xx = (response.output.statusCode < 500) || (response.output.statusCode > 599);
+      const omittedResponseCodes = options.omittedResponseCodes || [];
+      const doNotIgnoreThisResponseCode = omittedResponseCodes.indexOf(response.output.statusCode) === -1;
+      const shouldHandleError = responseIsNot5xx && doNotIgnoreThisResponseCode;
 
-      if (responseIsNot5xx) {
+      if (shouldHandleError) {
         // submit error
         rollbar.handleError(response, exports.relevantProperties(request), function(/*er1*/) {
 

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "rollbar": "^0.5.12"
   },
   "devDependencies": {
-    "boom": "^2.8.0",
-    "code": "^1.4.1",
-    "hapi": "8.x.x",
-    "lab": "5.13.x",
-    "sinon": "^1.15.3"
+    "boom": "3.x.x",
+    "code": "2.x.x",
+    "hapi": "11.x.x",
+    "lab": "7.x.x",
+    "sinon": "1.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icecreambar",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "hapi plugin for rollbar error logging",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,11 @@ lab.experiment('server', function () {
   lab.beforeEach(function(done) {
 
     server = new Hapi.Server();
-    server.connection({});
+    server.connection({ port: 80, labels: 'a' });
+    server.connection({ port: 8080, labels: 'b' });
+
+    // suppress internal output
+    console.error = function(){};
 
     done();
   });
@@ -107,7 +111,7 @@ lab.experiment('server', function () {
       }
     });
 
-    server.inject('/foo', function(/*request, reply*/) {
+    server.connections[0].inject('/foo', function(/*request, reply*/) {
 
       expect(server.plugins.icecreambar.foo.handleError.called).to.equal(true);
       done();
@@ -138,7 +142,7 @@ lab.experiment('server', function () {
       }
     });
 
-    server.inject('/foo', function(/*request, reply*/) {
+    server.connections[0].inject('/foo', function(/*request, reply*/) {
 
       expect(server.plugins.icecreambar.foo.handleError.called).to.equal(true);
       done();
@@ -165,7 +169,7 @@ lab.experiment('server', function () {
         }
       });
 
-      server.inject('/foo', function(/*request, reply*/) {
+      server.connections[0].inject('/foo', function(/*request, reply*/) {
 
         expect(server.plugins.icecreambar.foo.handleError.called).to.equal(false);
         done();
@@ -219,7 +223,7 @@ lab.experiment('server', function () {
           }
         });
 
-        server.inject('/foo', function(/*request, reply*/) {
+        server.connections[0].inject('/foo', function(/*request, reply*/) {
 
           // node caches the result of `require('rollbar')` thus both
           // `icecreambar.foo` and `icecreambar.bar` are the same object in memory

--- a/test/log.js
+++ b/test/log.js
@@ -279,11 +279,4 @@ lab.experiment('log', function () {
       });
     });
   });
-
-  lab.test('decorateRequest ignores a null argument', function (done) {
-
-    const decorateRequest = require('../index.js').decorateRequest;
-    expect(decorateRequest()).to.equal(null);
-    done();
-  });
 });


### PR DESCRIPTION
because we log way too many 401s.
