### PR TITLE
update dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "env": {
-    "node": true
+    "node": true,
+    "es6": true
   },
 
   "ecmaFeatures": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - "4.2.2"
+  - "4"
+  - "6"
 notifications:
   email: false
 cache:

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,5 @@
-machine:
-  node:
-    version: v4.2.2
+test:
+    override:
+        - nvm use 4 && npm test
+        - nvm install 6
+        - nvm use 6 && npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "hapi plugin for rollbar error logging",
   "main": "index.js",
   "scripts": {
-    "test": "node --use_strict --harmony --harmony_arrow_functions ./node_modules/.bin/lab --lint -c"
+    "test": "node --use_strict ./node_modules/.bin/lab --lint -c"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "url": "https://github.com/yayuhh/icecreambar/issues"
   },
   "dependencies": {
-    "rollbar": "^0.5.12"
+    "rollbar": "^0.6.2"
   },
   "devDependencies": {
     "boom": "3.x.x",
-    "code": "2.x.x",
+    "code": "3.x.x",
     "hapi": "11.x.x",
-    "lab": "7.x.x",
+    "lab": "10.x.x",
     "sinon": "1.x.x"
   }
 }


### PR DESCRIPTION
Hi,

This PR does the following:
- updates package to use the latest 0.6.x node-rollbar release
- updates hapi lab/code dependencies
- updates travis to test on node 4/6 (these are the versions hapi _officially_ supports)
- removed unnecessary harmony flags when testing
- fixed an issue where the linter was complaining that const was a reserved keyword (see [this thread](https://github.com/hapijs/lab/issues/526#issuecomment-186664881))

Thanks!
