### PR TITLE
properlygate errors to rollbar :derp:

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,27 +21,29 @@ exports.register = function (server, options, next) {
 
   // events logged with server.log()
   server.on('log', function (event, tags) {
+    const data = event.data;
 
     // if this ERROR is intended for Rollbar
     if (tags.rollbarError) {
-      rollbar.handleError(event);
+      rollbar.handleError(data);
     }
 
     // if this MESSAGE is intended for Rollbar
     if (tags.rollbarMessage) {
-      rollbar.reportMessage(event, 'info');
+      rollbar.reportMessage(data, 'info');
     }
   });
 
   // events logged with request.log()
   server.on('request', function (request, event, tags) {
+    const data = event.data;
 
     // if this ERROR is intended for Rollbar
     if (tags.rollbarError) {
-      let custom = event.data ? event.data : undefined;
+      const custom = (data && data.data) ? data.data : undefined;
 
       rollbar.handleErrorWithPayloadData(
-        event,
+        data,
         { level: 'error', custom },
         exports.relevantProperties(request, options.personTracking)
       );
@@ -49,7 +51,7 @@ exports.register = function (server, options, next) {
 
     // if this MESSAGE is intended for Rollbar
     if (tags.rollbarMessage) {
-      rollbar.reportMessage(event, 'info', exports.relevantProperties(request, options.personTracking));
+      rollbar.reportMessage(data, 'info', exports.relevantProperties(request, options.personTracking));
     }
   });
 
@@ -83,8 +85,8 @@ var extractUser = function(credentials, personTracking) {
     id: credentials[personTracking.id],
     email: credentials[personTracking.email],
     username: credentials[personTracking.username],
-  }
-}
+  };
+};
 
 exports.relevantProperties = function(request, personTracking) {
   return {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icecreambar",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "hapi plugin for rollbar error logging",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
![](http://25.media.tumblr.com/e7898e4d00b6a3dd6164fb4f1e09ac4c/tumblr_mt1vhbGdpp1s2cd24o1_500.gif)

we treated `event` as our emitted error, but `event` is a hapi object
wrapping our error and naming it `data`