### PR TITLE
added check to make sure credentials exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,11 +84,15 @@ exports.plugin = {
 };
 
 const extractUser = function(credentials, personTracking) {
-  return {
-    id: credentials[personTracking.id],
-    email: credentials[personTracking.email],
-    username: credentials[personTracking.username],
-  };
+  if (personTracking && credentials) {
+    return {
+      id: credentials[personTracking.id],
+      email: credentials[personTracking.email],
+      username: credentials[personTracking.username],
+    }; 
+  }
+
+  return undefined;
 };
 
 exports.relevantProperties = function(request, personTracking) {
@@ -97,6 +101,6 @@ exports.relevantProperties = function(request, personTracking) {
     url: request.path,
     method: request.method,
     body: request.payload,
-    rollbar_person: personTracking ? extractUser(request.auth.credentials, personTracking) : undefined
+    rollbar_person: extractUser(request.auth.credentials, personTracking)
   };
 };

--- a/test/index.js
+++ b/test/index.js
@@ -183,4 +183,19 @@ lab.experiment('server', function () {
       'username' : 'test'
     });
   });
+
+  lab.test('rollbar_person undefined when credential are empty', async () => {
+
+    const fn = (request, h) =>{
+
+      const err = Boom.create(501);
+      err.data = 'arbitrary stuff';
+
+      return err;
+    };
+
+    await register(fn, { personTracking : {} });
+
+    expect(server.plugins.icecreambar.handleErrorWithPayloadData.args[0][2].rollbar_person).to.be.undefined();
+  });
 });


### PR DESCRIPTION
I've run into a couple of cases where `credentials` can be `null` or `undefined` and the plugin will throw an error when trying to access the default properties for person tracking.

This PR adds a simple check to make sure both credentials and person tracking exist.